### PR TITLE
Enable docker container architecture for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ python:
 install: "pip install -r requirements.txt"
 # command to run tests
 script: py.test
+# run in a docker container
+sudo: false
 notifications:
   email: false


### PR DESCRIPTION
By adding `sudo: false` to the `.travis.yml` file we can speed up the CI tests by having Travis CI run them in docker containers rather than VMs.