### PR TITLE
http: Don't verify host if verify_ssl is disabled

### DIFF
--- a/osbs/http.py
+++ b/osbs/http.py
@@ -215,6 +215,7 @@ class PycurlAdapter(object):
         self.c.setopt(pycurl.WRITEFUNCTION, self.response.write)
         self.c.setopt(pycurl.HEADERFUNCTION, self.response_headers.write)
         self.c.setopt(pycurl.SSL_VERIFYPEER, 1 if verify_ssl else 0)
+        self.c.setopt(pycurl.SSL_VERIFYHOST, 1 if verify_ssl else 0)
         self.c.setopt(pycurl.VERBOSE, 1 if self.verbose else 0)
         if username and password:
             self.c.setopt(pycurl.USERPWD, b"%s:%s" % (username, password))


### PR DESCRIPTION
Sometimes OpenShift self-signed certificate isn't created correctly and
CommonName is 127.0.0.1 instead of IP address/FQDN under which is
OpenShift available. This change allows ignore this inconsistency which
would otherwise cause following fatal error:

>    SSL: certificate subject name (127.0.0.1) does not match target host
>    name 'openshift.example.com'