### PR TITLE
More coherent exception handling

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -2,7 +2,8 @@ from __future__ import print_function, unicode_literals, absolute_import
 import json
 from osbs.build import BuildManager, BuildResponse
 from osbs.constants import DEFAULT_NAMESPACE
-from osbs.core import Openshift, OpenshiftException
+from osbs.core import Openshift
+from osbs.exceptions import OsbsResponseException
 
 
 class OSBS(object):
@@ -66,7 +67,7 @@ class OSBS(object):
             return self.os.logs(build_id, follow, namespace=namespace)
         try:
             build = self.os.get_build(build_id, namespace=namespace)
-        except OpenshiftException as ex:
+        except OsbsResponseException as ex:
             if ex.status_code != 404:
                 raise
         else:

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -3,6 +3,7 @@ import json
 
 import logging
 from osbs.constants import DEFAULT_NAMESPACE, BUILD_FINISHED_STATES, BUILD_RUNNING_STATES, BUILD_PENDING_STATES
+from osbs.exceptions import OsbsResponseException
 
 try:
     # py2
@@ -19,18 +20,18 @@ from .http import get_http_session
 logger = logging.getLogger(__name__)
 
 
-class OpenshiftException(Exception):
+class OsbsResponseException(Exception):
     """ OpenShift didn't respond with OK (200) status """
 
     def __init__(self, message, status_code, *args, **kwargs):
-        super(OpenshiftException, self).__init__(message, *args, **kwargs)
+        super(OsbsResponseException, self).__init__(message, *args, **kwargs)
         self.status_code = status_code
 
 
 def check_response(response):
     if response.status_code not in (httplib.OK, httplib.CREATED):
         logger.error("[%s] %s", response.status_code, response.content)
-        raise OpenshiftException(message=response.content, status_code=response.status_code)
+        raise OsbsResponseException(message=response.content, status_code=response.status_code)
 
 
 # TODO: error handling: create function which handles errors in response object

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -20,14 +20,6 @@ from .http import get_http_session
 logger = logging.getLogger(__name__)
 
 
-class OsbsResponseException(Exception):
-    """ OpenShift didn't respond with OK (200) status """
-
-    def __init__(self, message, status_code, *args, **kwargs):
-        super(OsbsResponseException, self).__init__(message, *args, **kwargs)
-        self.status_code = status_code
-
-
 def check_response(response):
     if response.status_code not in (httplib.OK, httplib.CREATED):
         logger.error("[%s] %s", response.status_code, response.content)

--- a/osbs/exceptions.py
+++ b/osbs/exceptions.py
@@ -1,0 +1,17 @@
+"""
+Exceptions raised by OSBS
+"""
+
+class OsbsException(Exception):
+    pass
+
+class OsbsResponseException(OsbsException):
+    def __init__ (self, message, status_code, *args, **kwargs):
+        super (OsbsException, self).__init__ (message, *args, **kwargs)
+        self.status_code = status_code
+
+class OsbsNetworkException(OsbsException):
+    def __init__ (self, url, message, status_code, *args, **kwargs):
+        super (OsbsNetworkException, self).__init__ (message, *args, **kwargs)
+        self.url = url
+        self.status_code = status_code

--- a/osbs/exceptions.py
+++ b/osbs/exceptions.py
@@ -6,6 +6,8 @@ class OsbsException(Exception):
     pass
 
 class OsbsResponseException(OsbsException):
+    """ OpenShift didn't respond with OK (200) status """
+
     def __init__ (self, message, status_code, *args, **kwargs):
         super (OsbsResponseException, self).__init__ (message, *args, **kwargs)
         self.status_code = status_code

--- a/osbs/exceptions.py
+++ b/osbs/exceptions.py
@@ -7,7 +7,7 @@ class OsbsException(Exception):
 
 class OsbsResponseException(OsbsException):
     def __init__ (self, message, status_code, *args, **kwargs):
-        super (OsbsException, self).__init__ (message, *args, **kwargs)
+        super (OsbsResponseException, self).__init__ (message, *args, **kwargs)
         self.status_code = status_code
 
 class OsbsNetworkException(OsbsException):


### PR DESCRIPTION
New exceptions module with base OsbsException class and two
exceptions derived from it:
 * OsbsResponseException, for OpenShift 'fail' responses
 * OsbsNetworkException, for (possibly transient) network
   failures

The OsbsResponseException is thrown by the api and core modules
when they see a fail HTTP response.

The PycurlAdapter class catches exceptions thrown during
request handling and maps them to either OsbsNetworkException
or OsbsException as appropriate.

This fixes #43.