### PR TITLE
add landscape.io config

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,0 +1,18 @@
+doc-warnings: no
+test-warnings: no
+strictness: veryhigh
+max-line-length: 120
+autodetect: yes
+requirements:
+  - requirements.txt
+ignore-paths:
+  - docs
+mccabe:
+  run: false
+pep8:
+  disable:
+    - C0103
+pylint:
+  disable:
+    - R0903
+    - C0103


### PR DESCRIPTION
Fixes #53 

This enables [pep8](https://www.python.org/dev/peps/pep-0008/). I would really like if our code could be pep8 compliant. Especially when you can enable pep8 in you text editors/IDEs. What do you think?