### PR TITLE
Configure add_yum_repo_by_url plugin

### DIFF
--- a/inputs/prod-without-koji_inner.json
+++ b/inputs/prod-without-koji_inner.json
@@ -16,6 +16,12 @@
       "name": "distgit_fetch_artefacts"
     },
     {
+      "args": {
+        "repourls": []
+      },
+      "name": "add_yum_repo_by_url"
+    },
+    {
       "name": "inject_yum_repo"
     },
     {

--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -24,6 +24,12 @@
       "name": "koji"
     },
     {
+      "args": {
+        "repourls": []
+      },
+      "name": "add_yum_repo_by_url"
+    },
+    {
       "name": "inject_yum_repo"
     },
     {

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -101,7 +101,8 @@ class OSBS(object):
         return build_response
 
     @osbsapi
-    def create_prod_build(self, git_uri, git_ref, user, component, target, architecture, namespace=DEFAULT_NAMESPACE):
+    def create_prod_build(self, git_uri, git_ref, user, component, target, architecture, yum_repourls=None,
+                          namespace=DEFAULT_NAMESPACE):
         build_request = self.get_build_request(PROD_BUILD_TYPE)
         build_request.set_params(
             git_uri=git_uri,
@@ -118,6 +119,7 @@ class OSBS(object):
             vendor=self.build_conf.get_vendor(),
             build_host=self.build_conf.get_build_host(),
             authoritative_registry=self.build_conf.get_authoritative_registry(),
+            yum_repourls=yum_repourls,
             metadata_plugin_use_auth=self.build_conf.get_metadata_plugin_use_auth(),
         )
         build_json = build_request.render()
@@ -127,7 +129,7 @@ class OSBS(object):
         return build_response
 
     @osbsapi
-    def create_prod_without_koji_build(self, git_uri, git_ref, user, component, architecture,
+    def create_prod_without_koji_build(self, git_uri, git_ref, user, component, architecture, yum_repourls=None,
                                        namespace=DEFAULT_NAMESPACE):
         build_request = self.get_build_request(PROD_WITHOUT_KOJI_BUILD_TYPE)
         build_request.set_params(
@@ -142,6 +144,7 @@ class OSBS(object):
             vendor=self.build_conf.get_vendor(),
             build_host=self.build_conf.get_build_host(),
             authoritative_registry=self.build_conf.get_authoritative_registry(),
+            yum_repourls=yum_repourls,
             metadata_plugin_use_auth=self.build_conf.get_metadata_plugin_use_auth(),
         )
         build_json = build_request.render()
@@ -150,7 +153,8 @@ class OSBS(object):
         return build_response
 
     @osbsapi
-    def create_simple_build(self, git_uri, git_ref, user, component, namespace=DEFAULT_NAMESPACE):
+    def create_simple_build(self, git_uri, git_ref, user, component, yum_repourls=None,
+                            namespace=DEFAULT_NAMESPACE):
         build_request = self.get_build_request(SIMPLE_BUILD_TYPE)
         build_request.set_params(
             git_uri=git_uri,
@@ -159,6 +163,7 @@ class OSBS(object):
             component=component,
             registry_uri=self.build_conf.get_registry_uri(),
             openshift_uri=self.os_conf.get_openshift_api_uri(),
+            yum_repourls=yum_repourls,
         )
         build_json = build_request.render()
         response = self.os.create_build(json.dumps(build_json), namespace=namespace)

--- a/osbs/build/manipulate.py
+++ b/osbs/build/manipulate.py
@@ -30,21 +30,42 @@ class DockJsonManipulator(object):
         dock_json = json.loads(dock_json_str)
         return dock_json
 
-    def _dock_json_get_plugin_conf(self, plugin_type, plugin_name):
-        try:
-            match = [x for x in self.dock_json[plugin_type] if x.get('name', None) == plugin_name]
-        except KeyError:
-            raise RuntimeError("Invalid dock json: plugin type '%s' misses" % plugin_type)
-        if len(match) <= 0:
-            raise RuntimeError("no such plugin in dock json: \"%s\"" % plugin_name)
+    def dock_json_get_plugin_conf(self, plugin_type, plugin_name):
+        """
+        Return the configuration for a plugin.
+
+        Raises KeyError if there are no plugins of that type.
+        Raises IndexError if the named plugin is not listed.
+        """
+        match = [x for x in self.dock_json[plugin_type] if x.get('name', None) == plugin_name]
         return match[0]
 
+    def dock_json_has_plugin_conf(self, plugin_type, plugin_name):
+        """
+        Check whether a plugin is configured.
+        """
+
+        try:
+            self.dock_json_get_plugin_conf(plugin_type, plugin_name)
+            return True
+        except (KeyError, IndexError):
+            return False
+
+    def _dock_json_get_plugin_conf_or_fail(self, plugin_type, plugin_name):
+        try:
+            conf = self.dock_json_get_plugin_conf(plugin_type, plugin_name)
+        except KeyError:
+            raise RuntimeError("Invalid dock json: plugin type '%s' misses" % plugin_type)
+        except IndexError:
+            raise RuntimeError("no such plugin in dock json: \"%s\"" % plugin_name)
+        return conf
+
     def dock_json_set_arg(self, plugin_type, plugin_name, arg_key, arg_value):
-        plugin_conf = self._dock_json_get_plugin_conf(plugin_type, plugin_name)
+        plugin_conf = self._dock_json_get_plugin_conf_or_fail(plugin_type, plugin_name)
         plugin_conf['args'][arg_key] = arg_value
 
     def dock_json_merge_arg(self, plugin_type, plugin_name, arg_key, arg_dict):
-        plugin_conf = self._dock_json_get_plugin_conf(plugin_type, plugin_name)
+        plugin_conf = self._dock_json_get_plugin_conf_or_fail(plugin_type, plugin_name)
 
         # Values supplied by the caller override those from the template JSON
         template_value = plugin_conf['args'].get(arg_key, {})
@@ -61,4 +82,3 @@ class DockJsonManipulator(object):
         if len(p) <= 0:
             raise RuntimeError("\"env\" misses key DOCK_PLUGINS")
         p[0]['value'] = json.dumps(self.dock_json)
-

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -81,6 +81,7 @@ class CommonSpec(BuildTypeSpec):
     registry_uri = BuildParam('registry_uri')
     openshift_uri = BuildParam('openshift_uri')
     name = BuildParam("name")
+    yum_repourls = BuildParam("yum_repourls")
 
     def __init__(self):
         self.required_params = [
@@ -93,13 +94,16 @@ class CommonSpec(BuildTypeSpec):
         ]
 
     def set_params(self, git_uri=None, git_ref=None, registry_uri=None, user=None,
-                   component=None, openshift_uri=None, **kwargs):
+                   component=None, openshift_uri=None, yum_repourls=None, **kwargs):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
         self.user.value = user
         self.component.value = component
         self.registry_uri.value = registry_uri
         self.openshift_uri.value = openshift_uri
+        if not (yum_repourls is None or isinstance(yum_repourls, list)):
+            raise OsbsValidationException("yum_repourls must be a list")
+        self.yum_repourls.value = yum_repourls or []
         d = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
         self.name.value = "%s-%s" % (self.component.value, d)
 

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -127,7 +127,8 @@ def cmd_build(args, osbs):
         component=args.component,
         target=args.target,
         architecture=args.arch,
-        namespace=args.namespace
+        yum_repourls=args.add_yum_repo,
+        namespace=args.namespace,
     )
     build_id = build.build_id
     if not args.no_logs:
@@ -246,6 +247,8 @@ def cli():
                               help="name of component")
     build_parser.add_argument("--no-logs", action='store_true', required=False, default=False,
                               help="don't print logs after submitting build")
+    build_parser.add_argument("--add-yum-repo", action='append', metavar="URL",
+                              help="URL of yum repo file")
     build_parser.set_defaults(func=cmd_build)
 
     parser.add_argument("--openshift-uri", action='store', metavar="URL",


### PR DESCRIPTION
This adds support for configuring the [new `add_yum_repo_by_url` plugin in dock](https://github.com/DBuildService/dock/pull/78).

* Configuration for plugin in prod_inner.json.
* Keyword argument for OSBS.create_build, `yum_repourls`.
* ProductionBuild fills in configuration (if present) from
  keyword argument.
* Test case for the above.
* New CLI argument for build, `--add-yum-repo URI`.