### PR TITLE
Explicit exception chaining and enhanced reporting.

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -9,6 +9,7 @@ from __future__ import print_function, unicode_literals, absolute_import
 
 import json
 import logging
+import sys
 from functools import wraps
 
 from .constants import SIMPLE_BUILD_TYPE, PROD_WITHOUT_KOJI_BUILD_TYPE
@@ -30,7 +31,12 @@ def osbsapi(func):
             raise
         except Exception as ex:
             # Convert anything else to OsbsException
-            raise OsbsException(repr(ex))
+
+            # Python 3 has implicit exception chaining and enhanced
+            # reporting, so you get the original traceback as well as
+            # the one originating here.
+            # For Python 2, let's do that explicitly.
+            raise OsbsException(cause=ex, traceback=sys.exc_info()[2])
 
     return catch_exceptions
 

--- a/osbs/exceptions.py
+++ b/osbs/exceptions.py
@@ -9,9 +9,33 @@ of the BSD license. See the LICENSE file for details.
 Exceptions raised by OSBS
 """
 
+from traceback import format_tb
+
 
 class OsbsException(Exception):
-    pass
+    def __init__(self, message=None, cause=None, traceback=None):
+        if message is None and cause is not None:
+            message = repr(cause)
+
+        super(OsbsException, self).__init__(message)
+        self.message = message
+        self.cause = cause
+        self.traceback = traceback
+
+    def __str__(self):
+        if self.cause and self.traceback and not hasattr(self, '__context__'):
+            return ("%s\n\n" % self.message +
+                    "Original traceback (most recent call last):\n" +
+                    "".join(format_tb(self.traceback)) +
+                    "%r" % self.cause)
+        else:
+            return super(OsbsException, self).__str__()
+
+    def __repr__(self):
+        if self.cause and not hasattr(self, '__context__'):
+            return "OsbsException caused by %r" % self.cause
+        else:
+            return super(OsbsException, self).__repr__()
 
 
 class OsbsResponseException(OsbsException):


### PR DESCRIPTION
Converting all exceptions to OsbsException can lose information about the context of the original exception. It would be nice to be able to show that context.

This happens implicitly with Python 3, but to aid reporting with Python 2 we can do it explicitly.

This is only activated in Python 2, by detecting whether the `__context__` attribute is set.

Before:
```
Traceback (most recent call last):
  File "/usr/bin/osbs", line 9, in <module>
    load_entry_point('osbs==0.4', 'console_scripts', 'osbs')()
  File "build/bdist.linux-x86_64/egg/osbs/cli/main.py", line 311, in main
  File "build/bdist.linux-x86_64/egg/osbs/cli/main.py", line 153, in cmd_build_logs
  File "build/bdist.linux-x86_64/egg/osbs/api.py", line 33, in catch_exceptions
osbs.exceptions.OsbsException: TypeError("'Response' object has no attribute '__getitem__'",)
```

After:
```
Traceback (most recent call last):
  File "/usr/bin/osbs", line 9, in <module>
    load_entry_point('osbs==0.4', 'console_scripts', 'osbs')()
  File "build/bdist.linux-x86_64/egg/osbs/cli/main.py", line 311, in main
  File "build/bdist.linux-x86_64/egg/osbs/cli/main.py", line 153, in cmd_build_logs
  File "build/bdist.linux-x86_64/egg/osbs/api.py", line 39, in catch_exceptions
osbs.exceptions.OsbsException: TypeError("'Response' object has no attribute '__getitem__'",)

Original traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/osbs/api.py", line 28, in catch_exceptions
    return func(*args, **kwargs)
  File "build/bdist.linux-x86_64/egg/osbs/api.py", line 209, in get_build_logs
    if build["status"] in ["Complete", "Failed"]:
TypeError("'Response' object has no attribute '__getitem__'",)
```