### PR TITLE
OSBS.get_build_logs(): use BuildResponse for state parsing

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -207,9 +207,8 @@ class OSBS(object):
                 raise
         else:
             build_response = BuildResponse(build)
-            # Should this be 'build_response.is_finished()'?
             logs = None
-            if build_response.json["status"] in ["Complete", "Failed"]:
+            if build_response.is_finished():
                 metadata = build_response.json.get("metadata", {})
                 md = metadata.get("annotations", metadata.get("labels", {}))
                 logs = md.get("logs", None)


### PR DESCRIPTION
Could do with more mock JSON responses for better test coverage, especially errored/cancelled builds.

From line note in #66: https://github.com/DBuildService/osbs/pull/66/files#r30439416