### PR TITLE
Tests for osbs.api.OSBS class

### DIFF
--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -141,9 +141,12 @@ def openshift():
 def osbs():
     with NamedTemporaryFile(mode="wt") as fp:
         fp.write("""
+[general]
+build_json_dir = {build_json_dir}
 [default]
 openshift_uri = https://0.0.0.0/
-""")
+build_type = simple
+""".format (build_json_dir="inputs"))
         fp.flush()
         dummy_config = Configuration(fp.name)
         osbs = OSBS(dummy_config, dummy_config)


### PR DESCRIPTION
Here are some tests for the `osbs.api.OSBS` class. It calls most of the methods and largely checks their return value types.

Still missing:
 * `create_prod_build()`
 * `create_prod_without_koji_build()`
 * `create_simple_build()`
 * `create_build()`
 * `create_build_from_buildrequest()`
 * `wait_for_build_to_finish()`