### PR TITLE
Pass two arguments to string used in OsbsException

### DIFF
--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -85,7 +85,7 @@ class BuildRequest(object):
                     self._template = json.load(fp)
             except (IOError, OSError) as ex:
                 raise OsbsException("Can't open template '%s': %s" %
-                                    path, repr(ex))
+                                    (path, repr(ex)))
         return self._template
 
     @property


### PR DESCRIPTION
Before this change following exception was raised:

  File ".../osbs/osbs/build/build_request.py", line 88, in template
    path, repr(ex))
TypeError('not enough arguments for format string',)

For a reference I've called osbs with following commands:
```
echo -e "\n[default]\nsources_command=\nvendor=\nbuild_host=\nauthoritative_registry=\n" > /tmp/osbs.conf
osbs --verbose --config /tmp/osbs.conf --openshift-uri http://127.0.0.1:9443 --registry-uri 127.0.0.1:5000 build -u pbabinca --arch x86_64 --git-commit master -g 'git+http://github.com/TomasTomecek/docker-hello-world' -c docker-hello-world --build-type prod-without-koji --build-json-dir /nonexistent
```