### PR TITLE
Use architecture as destination name in argparse

### DIFF
--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -239,7 +239,7 @@ def cli():
                               help="checkout this commit")
     build_parser.add_argument("-t", "--target", action='store',
                               help="koji target name")
-    build_parser.add_argument("-a", "--arch", action='store', default=uname()[4],
+    build_parser.add_argument("-a", "--arch", dest='architecture', action='store', default=uname()[4],
                               help="build architecture")
     build_parser.add_argument("-u", "--user", action='store', required=True,
                               help="username (will be image prefix)")


### PR DESCRIPTION
This name is used in the rest of the code. Before it wasn't possible to
set architecture and following exception was raised:

  ...
  File ".../osbs/osbs/build/spec.py", line 70, in validate
    raise OsbsValidationException("param '%s' is not valid: None is not allowed" % param.name)
osbs.exceptions.OsbsValidationException: param 'architecture' is not valid: None is not allowed

For a reference I've called osbs with following commands:
```
echo -e "\n[default]\nsources_command=\nvendor=\nbuild_host=\nauthoritative_registry=\n" > /tmp/osbs.conf
osbs --verbose --config /tmp/osbs.conf --openshift-uri http://127.0.0.1:9443 --registry-uri 127.0.0.1:5000 build -u pbabinca --arch x86_64 --git-commit master -g 'git+http://github.com/TomasTomecek/docker-hello-world' -c docker-hello-world --build-type prod-without-koji --build-json-dir /nonexistent
```