### PR TITLE
inputs: add_labels_in_dockerfile must be run before add_dockerfile

### DIFF
--- a/inputs/prod-without-koji_inner.json
+++ b/inputs/prod-without-koji_inner.json
@@ -4,13 +4,13 @@
       "name": "change_from_in_dockerfile"
     },
     {
-      "name": "add_dockerfile"
-    },
-    {
       "args": {
         "labels": "{{IMPLICIT_LABELS}}"
       },
       "name": "add_labels_in_dockerfile"
+    },
+    {
+      "name": "add_dockerfile"
     },
     {
       "args": {

--- a/inputs/prod_inner.json
+++ b/inputs/prod_inner.json
@@ -4,13 +4,13 @@
       "name": "change_from_in_dockerfile"
     },
     {
-      "name": "add_dockerfile"
-    },
-    {
       "args": {
         "labels": "{{IMPLICIT_LABELS}}"
       },
       "name": "add_labels_in_dockerfile"
+    },
+    {
+      "name": "add_dockerfile"
     },
     {
       "args": {


### PR DESCRIPTION
add_dockerfile gets N-V-R either from nvr argument or from
LABELs in Dockerfile. If the LABELs are added to Dockerfile with
add_labels_in_dockerfile then it has to be run before add_dockerfile.