### PR TITLE
http: string decoding, py 2.{6,7} compat

### DIFF
--- a/osbs/http.py
+++ b/osbs/http.py
@@ -348,7 +348,7 @@ class PycurlAdapter(object):
             # self.response_headers contains headers from all responses - even
             # without FOLLOWLOCATION there might be multiple sets of headers
             # due to 401 Unauthorized. We only care about the last response.
-            allheaders = self.response_headers.getvalue().decode(errors='replace')
+            allheaders = self.response_headers.getvalue().decode("ascii", 'replace')  # py 2.{6,7} compat
             response.raw_headers = allheaders.split("\r\n\r\n")[-2]
 
             response.curl = self.c
@@ -362,7 +362,7 @@ class PycurlAdapter(object):
             # self.response_headers contains headers from all responses - even
             # without FOLLOWLOCATION there might be multiple sets of headers
             # due to 401 Unauthorized. We only care about the last response.
-            allheaders = self.response_headers.getvalue().decode(errors='replace')
+            allheaders = self.response_headers.getvalue().decode("ascii", 'replace')  # py 2.{6,7} compat
             try:
                 response.raw_headers = allheaders.split("\r\n\r\n")[-2]
             except IndexError:


### PR DESCRIPTION
2.6 doesn't have keyword arguments therefore it fails with:

TypeError('decode() takes no keyword arguments',)

Fixes #86