### PR TITLE
API CHANGE: all api calls return BuildResponse

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -70,9 +70,12 @@ class OSBS(object):
 
     @osbsapi
     def list_builds(self, namespace=DEFAULT_NAMESPACE):
-        # FIXME: return list of BuildResponse objects
-        builds = self.os.list_builds(namespace=namespace).json()
-        return builds
+        response = self.os.list_builds(namespace=namespace)
+        serialized_response = response.json()
+        build_list = []
+        for build in serialized_response["items"]:
+            build_list.append(BuildResponse(response, build))
+        return build_list
 
     @osbsapi
     def get_build(self, build_id, namespace=DEFAULT_NAMESPACE):
@@ -219,10 +222,9 @@ class OSBS(object):
 
     @osbsapi
     def wait_for_build_to_finish(self, build_id, namespace=DEFAULT_NAMESPACE):
-        # FIXME: since OS returns whole build json in watch we could return
-        #        instance of BuildResponse here
         response = self.os.wait_for_build_to_finish(build_id, namespace=namespace)
-        return response
+        build_response = BuildResponse(None, response)
+        return build_response
 
     @osbsapi
     def set_labels_on_build(self, build_id, labels, namespace=DEFAULT_NAMESPACE):

--- a/osbs/build/build_response.py
+++ b/osbs/build/build_response.py
@@ -5,20 +5,27 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+import json
+import logging
 
+from osbs.utils import graceful_chain_get
 from osbs.constants import BUILD_FINISHED_STATES, BUILD_RUNNING_STATES, \
     BUILD_SUCCEEDED_STATES, BUILD_FAILED_STATES
+
+
+logger = logging.getLogger(__name__)
 
 
 class BuildResponse(object):
     """ class which wraps json from http response from OpenShift """
 
-    def __init__(self, request):
+    def __init__(self, request, build_json=None):
         """
         :param request: http.Request
+        :param build_json: dict
         """
+        self._json = build_json
         self.request = request
-        self._json = None
         self._status = None
         self._build_id = None
 
@@ -51,3 +58,29 @@ class BuildResponse(object):
 
     def is_running(self):
         return self.status in BUILD_RUNNING_STATES
+
+    def get_build_name(self):
+        return graceful_chain_get(self.json, "metadata", "name")
+
+    def get_image_tag(self):
+        return graceful_chain_get(self.json, 'parameters', 'output', 'imageTag')
+
+    def get_annotations_or_labels(self):
+        r = graceful_chain_get(self.json, "metadata", "annotations")
+        if r is None:
+            r = graceful_chain_get(self.json, "metadata", "labels")
+        return r
+
+    def get_rpm_packages(self):
+        return graceful_chain_get(self.get_annotations_or_labels(), "rpm-packages")
+
+    def get_dockerfile(self):
+        return graceful_chain_get(self.get_annotations_or_labels(), "dockerfile")
+
+    def get_logs(self):
+        return graceful_chain_get(self.get_annotations_or_labels(), "logs")
+
+    def get_repositories(self):
+        repositories_json = graceful_chain_get(self.get_annotations_or_labels(), "repositories")
+        if repositories_json:
+            return json.loads(repositories_json)

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -240,8 +240,14 @@ class Openshift(object):
                 if obj_status.lower() in states:
                     response.close_multi()
                     return obj
+        # I'm not sure how we can end up here since there are two possible scenarios:
+        #   1. our object was found and we are returning in the loop
+        #   2. our object was not found and we keep waiting (in the loop)
+        # Therefore, let's raise here
+        logger.error("build '%s' was not found during wait", build_id)
         check_response(response)
-        return response
+        raise OsbsResponseException("build '%s' was not found and response stream ended" % build_id,
+                                    status_code=response.status_code)
 
     def wait_for_build_to_finish(self, build_id, namespace=DEFAULT_NAMESPACE):
         build_response = self.wait(build_id, BUILD_FINISHED_STATES, namespace)

--- a/osbs/core.py
+++ b/osbs/core.py
@@ -244,15 +244,13 @@ class Openshift(object):
         return response
 
     def wait_for_build_to_finish(self, build_id, namespace=DEFAULT_NAMESPACE):
-        while True:
-            build_response = self.wait(build_id, BUILD_FINISHED_STATES, namespace)
-            return build_response
+        build_response = self.wait(build_id, BUILD_FINISHED_STATES, namespace)
+        return build_response
 
     def wait_for_build_to_get_scheduled(self, build_id, namespace=DEFAULT_NAMESPACE):
-        while True:
-            build_response = self.wait(build_id, BUILD_FINISHED_STATES + BUILD_RUNNING_STATES,
-                                       namespace)
-            return build_response
+        build_response = self.wait(build_id, BUILD_FINISHED_STATES + BUILD_RUNNING_STATES,
+                                   namespace)
+        return build_response
 
     def set_labels_on_build(self, build_id, labels, namespace=DEFAULT_NAMESPACE):
         """

--- a/osbs/http.py
+++ b/osbs/http.py
@@ -373,6 +373,8 @@ class PycurlAdapter(object):
             # clear buffer
             self.response.truncate(0)
             self.response_headers.truncate(0)
+            # FIXME: don't close when we start reusing connection!
+            self.c.close()
         return response
 
     def _do_request(self, url, method, **kwargs):

--- a/osbs/http.py
+++ b/osbs/http.py
@@ -382,7 +382,11 @@ class PycurlAdapter(object):
             return self.request(url, method, **kwargs)
         except pycurl.error as ex:
             code = ex.args[0]
-            message = ex.args[1]
+            try:
+                message = ex.args[1]
+            except IndexError:
+                # happened on rhel 6
+                message = ""
             if code in PYCURL_NETWORK_CODES:
                 raise OsbsNetworkException(url, message, code, *ex.args[2:])
 

--- a/osbs/utils.py
+++ b/osbs/utils.py
@@ -1,0 +1,21 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+import copy
+
+
+def graceful_chain_get(d, *args):
+    if not d:
+        return None
+    t = copy.deepcopy(d)
+    for arg in args:
+        try:
+            t = t[arg]
+        except (AttributeError, KeyError):
+            return None
+    return t

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -396,11 +396,17 @@ def test_create_build(openshift):
 ## API tests (osbs.api.OSBS)
 
 def test_list_builds_api(osbs):
-    response = osbs.list_builds()
+    response_list = osbs.list_builds()
     # We should get a response
-    assert response is not None
-    # Response should have an 'items' key
-    assert 'items' in response
+    assert response_list is not None
+    assert len(response_list) > 0
+    # response_list is a list of BuildResponse objects
+    assert isinstance(response_list[0], BuildResponse)
+
+
+def test_wait_for_build_to_finish(osbs):
+    build_response = osbs.wait_for_build_to_finish(TEST_BUILD)
+    assert isinstance(build_response, BuildResponse)
 
 
 def test_get_build_api(osbs):


### PR DESCRIPTION
Fixes #90

This patch also introduces more methods for BuildResponse object so we
don't need to traverse in build json.

Also did some cleanup in

 * wait_for_build_to_*
 * cli/main.py

If anyone could review, please.
@pbabinca @twaugh 
