### PR TITLE
Ensure build_id property of BuildResponse is always unicode

### DIFF
--- a/osbs/build/build_response.py
+++ b/osbs/build/build_response.py
@@ -38,7 +38,7 @@ class BuildResponse(object):
     @property
     def status(self):
         if self._status is None:
-            self._status = self.json['status'].lower()
+            self._status = unicode(self.json['status'].lower())
         return self._status
 
     @property

--- a/osbs/build/build_response.py
+++ b/osbs/build/build_response.py
@@ -44,7 +44,7 @@ class BuildResponse(object):
     @property
     def build_id(self):
         if self._build_id is None:
-            self._build_id = self.json['metadata']['name']
+            self._build_id = unicode(self.json['metadata']['name'])
         return self._build_id
 
     def is_finished(self):

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -17,11 +17,11 @@ POD_RUNNING_STATES = ["pending", "running"]
 # https://github.com/GoogleCloudPlatform/kubernetes/blob/master/pkg/api/types.go
 # type PodPhase string
 # fixme: what about "unknown" state?
-BUILD_FINISHED_STATES = ["failed", "complete", "error", "cancelled"]
-BUILD_FAILED_STATES = ["failed", "error", "cancelled"]  # meaning no image produced
-BUILD_SUCCEEDED_STATES = ["complete"]
-BUILD_PENDING_STATES = ["pending", "new"]
-BUILD_RUNNING_STATES = ["running"]
+BUILD_FINISHED_STATES = [u"failed", u"complete", u"error", u"cancelled"]
+BUILD_FAILED_STATES = [u"failed", u"error", u"cancelled"]  # meaning no image produced
+BUILD_SUCCEEDED_STATES = [u"complete"]
+BUILD_PENDING_STATES = [u"pending", u"new"]
+BUILD_RUNNING_STATES = [u"running"]
 # https://github.com/openshift/origin/blob/master/pkg/build/api/types.go
 # type BuildStatus string
 DEFAULT_NAMESPACE = "default"


### PR DESCRIPTION
Without this osbs.core.wait():238 never ever found the build:

    if obj_name == build_id:

Line above compared isinstance(obj_name, unicode) with
isinstance(build_id, str). Tested on python 2.6.

For the rest of the osbs code where strings are used as identifiers you may want to explicitly type this as unicode().