### PR TITLE
Support for custom builds with source secrets

### DIFF
--- a/docs/secret.md
+++ b/docs/secret.md
@@ -1,0 +1,49 @@
+# Using a Source Secret
+
+The `prod-with-secret` build type allows you to provide some secret content to the build using [Kubernetes Secret Volumes](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/secrets.md).
+
+This is useful when the build workflow requires keys, certificates, etc, which should not be part of the buildroot image.
+
+The way it works is that a special resource, of type 'Secret', is manually created on the host. This resource is persistent and contains the secret data in the form of keys and base64-encoded values.
+
+Then, when a build container is created, a secret volume is created by OpenShift from that resource and mounted within the container at `$SOURCE_SECRET_PATH`. The secret values can then be accessed as files.
+
+
+## Creating the resource
+
+First, create the Secret resource.
+
+```
+$ cat secret.json
+{
+  "apiVersion": "v1beta3",
+  "kind": "Secret",
+  "metadata": {
+    "name": "mysecret",
+    "namespace": "default"
+  },
+  "data": {
+    "key": "-----BEGIN RSA PRIVATE KEY-----\n[...]",
+    "cert": "-----BEGIN CERTIFICATE-----\n[...]"
+  }
+}
+$ osc create -f secret.json
+secrets/mysecret
+```
+
+When you need to change the data, you can use `update` instead of `create`.
+
+## Configuring OSBS
+
+In your OSBS build instance configuration, use the following values:
+
+```
+build_type = prod-with-secret
+source_secret = mysecret
+```
+
+The `source_secret` name must match the resource name specified in the JSON.
+
+## Fetching the secrets within the build root
+
+In your `dock` plugin which needs the secret values, fetch the location of the Secret Volume mount from the environment variable `SOURCE_SECRET_PATH`. The files in that directory will match the keys from the secret resource's data (`key` and `cert`, from the JSON shown above).

--- a/inputs/prod-with-secret.json
+++ b/inputs/prod-with-secret.json
@@ -10,9 +10,7 @@
           "git" : {
             "uri": "{{GIT_URI}}"
           },
-          "sourceSecret": {
-            "name": "{{SOURCE_SECRET}}"
-          }
+          "sourceSecretName": "{{SOURCE_SECRET}}"
         },
         "strategy": {
           "type": "Custom",

--- a/inputs/prod-with-secret.json
+++ b/inputs/prod-with-secret.json
@@ -1,0 +1,33 @@
+{
+      "metadata":{
+        "name": "{{NAME}}"
+      },
+      "kind": "Build",
+      "apiVersion": "v1beta1",
+      "parameters": {
+        "source" : {
+          "type" : "Git",
+          "git" : {
+            "uri": "{{GIT_URI}}"
+          },
+          "sourceSecret": {
+            "name": "{{SOURCE_SECRET}}"
+          }
+        },
+        "strategy": {
+          "type": "Custom",
+          "customStrategy": {
+            "image": "buildroot",
+            "exposeDockerSocket": true,
+            "env": [{
+              "name": "DOCK_PLUGINS",
+              "value": "TBD"
+            }]
+          }
+        },
+        "output": {
+          "imageTag": "{{OUTPUT_IMAGE_TAG}}",
+          "registry": "{{REGISTRY_URI}}"
+        }
+      }
+}

--- a/inputs/prod-with-secret_inner.json
+++ b/inputs/prod-with-secret_inner.json
@@ -1,0 +1,83 @@
+{
+  "prebuild_plugins": [
+    {
+      "name": "change_from_in_dockerfile"
+    },
+    {
+      "name": "add_dockerfile"
+    },
+    {
+      "args": {
+        "labels": "{{IMPLICIT_LABELS}}"
+      },
+      "name": "add_labels_in_dockerfile"
+    },
+    {
+      "args": {
+        "command": "{{SOURCES_COMMAND}}"
+      },
+      "name": "distgit_fetch_artefacts"
+    },
+    {
+      "args": {
+        "root": "{{KOJI_ROOT}}",
+        "target": "{{KOJI_TARGET}}",
+        "hub": "{{KOJI_HUB}}"
+      },
+      "name": "koji"
+    },
+    {
+      "args": {
+        "repourls": []
+      },
+      "name": "add_yum_repo_by_url"
+    },
+    {
+      "name": "inject_yum_repo"
+    },
+    {
+      "name": "dockerfile_content"
+    },
+    {
+      "name": "change_source_registry",
+      "args": {
+        "registry_uri": "{{REGISTRY_URI}}",
+        "insecure_registry": true
+      }
+    }
+  ],
+  "prepublish_plugins": [
+    {
+      "name": "squash"
+    }
+  ],
+  "postbuild_plugins": [
+    {
+      "name": "tag_by_labels",
+      "args": {
+        "registry_uri": "{{REGISTRY_URI}}",
+        "insecure": true
+      }
+    },
+    {
+      "name": "tag_and_push"
+    },
+    {
+      "args": {
+        "image_id": "BUILT_IMAGE_ID"
+      },
+      "name": "all_rpm_packages"
+    },
+    {
+      "args": {
+        "url": "{{OPENSHIFT_URI}}",
+        "verify_ssl": false
+      },
+      "name": "store_metadata_in_osv3"
+    },
+    {
+      "name": "remove_built_image"
+    }
+  ]
+}
+

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -318,7 +318,7 @@ class ProductionWithSecretBuild(ProductionBuild):
             self.spec.validate()
         super(ProductionWithSecretBuild, self).render()
 
-        self.template['parameters']['source']['sourceSecret']['name'] = self.spec.source_secret.value
+        self.template['parameters']['source']['sourceSecretName'] = self.spec.source_secret.value
 
         self.build_json = self.template
         logger.debug(self.build_json)

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -216,6 +216,20 @@ class ProdWithoutKojiSpec(CommonProdSpec):
         )
 
 
+class ProdWithSecretSpec(ProdSpec):
+    source_secret = BuildParam("source_secret")
+
+    def __init__(self):
+        super(ProdWithSecretSpec, self).__init__()
+        self.required_params += [
+            self.source_secret,
+        ]
+
+    def set_params(self, source_secret=None, **kwargs):
+        super(ProdWithSecretSpec, self).set_params(**kwargs)
+        self.source_secret.value = source_secret
+
+
 class SimpleSpec(CommonSpec):
     image_tag = BuildParam("image_tag")
 

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -128,6 +128,7 @@ def cmd_build(args, osbs):
         architecture=osbs.build_conf.get_architecture(),
         yum_repourls=osbs.build_conf.get_yum_repourls(),
         namespace=osbs.build_conf.get_namespace(),
+        source_secret=osbs.build_conf.get_source_secret(),
     )
     build_id = build.build_id
     # we need to wait for kubelet to schedule the build, otherwise it's 500

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -255,6 +255,8 @@ def cli():
                               help="don't print logs after submitting build")
     build_parser.add_argument("--add-yum-repo", action='append', metavar="URL",
                               help="URL of yum repo file")
+    build_parser.add_argument("--source-secret", action='store', required=False,
+                              help="resource name of source secret")
     build_parser.set_defaults(func=cmd_build)
 
     parser.add_argument("--openshift-uri", action='store', metavar="URL",

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -207,3 +207,7 @@ class Configuration(object):
     def get_metadata_plugin_use_auth(self):
         return self._get_value("metadata_plugin_use_auth", self.conf_section, "metadata_plugin_use_auth",
                                can_miss=True, is_bool_val=True)
+
+    def get_source_secret(self):
+        return self._get_value("source_secret", self.conf_section,
+                               "source_secret", can_miss=True)

--- a/osbs/constants.py
+++ b/osbs/constants.py
@@ -30,4 +30,5 @@ DEFAULT_NAMESPACE = "default"
 
 PROD_BUILD_TYPE = "prod"
 PROD_WITHOUT_KOJI_BUILD_TYPE = "prod-without-koji"
+PROD_WITH_SECRET_BUILD_TYPE = "prod-with-secret"
 SIMPLE_BUILD_TYPE = "simple"

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -437,7 +437,7 @@ def test_render_prod_with_secret_request():
     build_request.set_params(**kwargs)
     build_json = build_request.render()
 
-    assert build_json["parameters"]["source"]["sourceSecret"]["name"] == "mysecret"
+    assert build_json["parameters"]["source"]["sourceSecretName"] == "mysecret"
 
 
 def test_render_with_yum_repourls():


### PR DESCRIPTION
This provides support for builds that require a secret, such as a key or certificate, as part of their workflow.

It assumes the OpenShift 'Secret'-type resource has already been created, and simply sets the `sourceSecret` resource name as directed.