### PR TITLE
simple build: use metadata_plugin_use_auth option

### DIFF
--- a/osbs/api.py
+++ b/osbs/api.py
@@ -201,6 +201,7 @@ class OSBS(object):
             registry_uri=self.build_conf.get_registry_uri(),
             openshift_uri=self.os_conf.get_openshift_api_uri(),
             yum_repourls=yum_repourls,
+            metadata_plugin_use_auth=self.build_conf.get_metadata_plugin_use_auth(),
         )
         build_json = build_request.render()
         response = self.os.create_build(json.dumps(build_json), namespace=namespace)

--- a/osbs/build/build_request.py
+++ b/osbs/build/build_request.py
@@ -127,6 +127,7 @@ class CommonBuild(BuildRequest):
         :param component: str, component part of the image name
         :param openshift_uri: str, URL of openshift instance for the build
         :param yum_repourls: list of str, URLs to yum repo files to include
+        :param metadata_plugin_use_auth: bool, use auth when posting metadata from dock?
         """
         logger.debug("setting params '%s' for %s", kwargs, self.spec)
         self.spec.set_params(**kwargs)
@@ -141,6 +142,10 @@ class CommonBuild(BuildRequest):
                 self.dj.dock_json_has_plugin_conf('prebuild_plugins', "add_yum_repo_by_url")):
             self.dj.dock_json_set_arg('prebuild_plugins', "add_yum_repo_by_url", "repourls",
                                       self.spec.yum_repourls.value)
+
+        if self.spec.metadata_plugin_use_auth.value is not None:
+            self.dj.dock_json_set_arg('postbuild_plugins', "store_metadata_in_osv3",
+                                      "use_auth", self.spec.metadata_plugin_use_auth.value)
 
     def validate_input(self):
         self.spec.validate()
@@ -179,9 +184,6 @@ class CommonProductionBuild(CommonBuild):
                              self.spec.registry_uri.value)
         dj.dock_json_set_arg('postbuild_plugins', "tag_by_labels", "registry_uri",
                              self.spec.registry_uri.value)
-        if self.spec.metadata_plugin_use_auth.value is not None:
-            dj.dock_json_set_arg('postbuild_plugins', "store_metadata_in_osv3",
-                                 "use_auth", self.spec.metadata_plugin_use_auth.value)
 
         implicit_labels = {
             'Architecture': self.spec.architecture.value,

--- a/osbs/build/spec.py
+++ b/osbs/build/spec.py
@@ -117,6 +117,7 @@ class CommonSpec(BuildTypeSpec):
     openshift_uri = BuildParam('openshift_uri')
     name = BuildIDParam()
     yum_repourls = BuildParam("yum_repourls")
+    metadata_plugin_use_auth = BuildParam("metadata_plugin_use_auth", allow_none=True)  # for debugging
 
     def __init__(self):
         self.required_params = [
@@ -129,7 +130,8 @@ class CommonSpec(BuildTypeSpec):
         ]
 
     def set_params(self, git_uri=None, git_ref=None, registry_uri=None, user=None,
-                   component=None, openshift_uri=None, yum_repourls=None, **kwargs):
+                   component=None, openshift_uri=None, yum_repourls=None,
+                   metadata_plugin_use_auth=None, **kwargs):
         self.git_uri.value = git_uri
         self.git_ref.value = git_ref
         self.user.value = user
@@ -139,6 +141,7 @@ class CommonSpec(BuildTypeSpec):
         if not (yum_repourls is None or isinstance(yum_repourls, list)):
             raise OsbsValidationException("yum_repourls must be a list")
         self.yum_repourls.value = yum_repourls or []
+        self.metadata_plugin_use_auth.value = metadata_plugin_use_auth
         self.name.value = self.component.value
 
 
@@ -148,7 +151,6 @@ class CommonProdSpec(CommonSpec):
     vendor = BuildParam("vendor")
     build_host = BuildParam("build_host")
     authoritative_registry = BuildParam("authoritative_registry ")
-    metadata_plugin_use_auth = BuildParam("metadata_plugin_use_auth", allow_none=True)  # for debugging
 
     def __init__(self):
         super(CommonProdSpec, self).__init__()
@@ -161,15 +163,13 @@ class CommonProdSpec(CommonSpec):
         ]
 
     def set_params(self, sources_command=None, architecture=None, vendor=None,
-                   build_host=None, authoritative_registry=None,
-                   metadata_plugin_use_auth=None, **kwargs):
+                   build_host=None, authoritative_registry=None, **kwargs):
         super(CommonProdSpec, self).set_params(**kwargs)
         self.sources_command.value = sources_command
         self.architecture.value = architecture
         self.vendor.value = vendor
         self.build_host.value = build_host
         self.authoritative_registry.value = authoritative_registry
-        self.metadata_plugin_use_auth.value = metadata_plugin_use_auth
 
 
 class ProdSpec(CommonProdSpec):


### PR DESCRIPTION
The simple build type ignored the value of metadata_plugin_use_auth even
though it has the store_metadata_in_osv3 plugin enabled.

Related to #41 and DBuildService/dock#134.

The other option is to remove *store_metadata_in_osv3* from the simple build json. I don't know if we want to have the plugin there or not.