### PR TITLE
Print http body if check_status_code raised HTTPError

### DIFF
--- a/osbs/http.py
+++ b/osbs/http.py
@@ -153,7 +153,12 @@ class Response(object):
 
     def json(self, check=True):
         if check:
-            self._check_status_code()
+            try:
+                self._check_status_code()
+            except HTTPError:
+                logger.exception("Original content with failed response: %s",
+                                 self.content)
+                raise
         return json.loads(self.content.decode(self.encoding))
 
     def _any_data_received(self):


### PR DESCRIPTION
Until now error message wasn't very useful even with verbose = True:

    File ".../osbs/osbs/api.py", line 28, in catch_exceptions
        return func(*args, **kwargs)
    File ".../osbs/osbs/api.py", line 74, in list_builds
        serialized_response = response.json()
    File ".../osbs/osbs/http.py", line 157, in json
        self._check_status_code()
    File ".../osbs/osbs/http.py", line 184, in _check_status_code
        raise HTTPError(url, self.status_code, message, None, None)
    HTTPError()

Full output with this change:

    $ osbs --without-auth list-builds
    2015-06-09 21:31:56,805 - osbs - DEBUG - Logging level set to debug
    * Adding handle: conn: 0x1234b80
    * Adding handle: send: 0
    * Adding handle: recv: 0
    * Curl_addHandleToPipeline: length: 1
    * - Conn 0 (0x1234b80) send_pipe: 1, recv_pipe: 0
    * About to connect() to builder.example.com port 8443 (#0)
    *   Trying 10.16.48.187...
    * Connected to builder.example.com (10.16.48.187) port 8443 (#0)
    * Initializing NSS with certpath: sql:/etc/pki/nssdb
    * skipping SSL peer certificate verification
    * NSS: client certificate not found (nickname not specified)
    * SSL connection using TLS_RSA_WITH_AES_128_CBC_SHA
    * Server certificate:
    *       subject: CN=10.16.48.187
    *       start date: May 28 11:06:51 2015 GMT
    *       expire date: May 27 11:06:52 2016 GMT
    *       common name: 10.16.48.187
    *       issuer: CN=openshift-signer@1432811210
    > GET /osapi/v1beta1/builds/?namespace=default HTTP/1.1
    User-Agent: PycURL/7.19.5.1 libcurl/7.32.0 NSS/3.18 Basic ECC zlib/1.2.8 libidn/1.28 libssh2/1.5.0
    Host: builder.example.com:8443
    Accept: */*

    < HTTP/1.1 403 Forbidden
    < Content-Type: application/json
    < Date: Tue, 09 Jun 2015 19:31:58 GMT
    < Content-Length: 290
    <
    * Connection #0 to host builder.example.com left intact
    2015-06-09 21:31:58,587 - osbs.http - ERROR - Original content with failed response: {
    "kind": "Status",
    "creationTimestamp": null,
    "apiVersion": "v1beta1",
    "status": "Failure",
    "message": "\"/osapi/v1beta1/builds/?namespace=default\" is forbidden because system:anonymous cannot list on builds in default",
    "reason": "Forbidden",
    "details": {},
    "code": 403
    }
    Traceback (most recent call last):
    File ".../osbs/osbs/http.py", line 157, in json
        self._check_status_code()
    File ".../osbs/osbs/http.py", line 184, in _check_status_code
        raise HTTPError(url, self.status_code, message, None, None)
    HTTPError: HTTP Error 403:
    Traceback (most recent call last):
    File "/home/pbabinca/.virtualenvs/osbsenv/bin/osbs", line 9, in <module>
        load_entry_point('osbs==0.8', 'console_scripts', 'osbs')()
    File ".../osbs/osbs/cli/main.py", line 317, in main
        args.func(args, osbs)
    File ".../osbs/osbs/cli/main.py", line 32, in cmd_list_builds
        builds = osbs.list_builds(namespace=args.namespace)
    File ".../osbs/osbs/api.py", line 39, in catch_exceptions
        raise OsbsException(cause=ex, traceback=sys.exc_info()[2])
    osbs.exceptions.OsbsException: HTTPError()

    Original traceback (most recent call last):
    File ".../osbs/osbs/api.py", line 28, in catch_exceptions
        return func(*args, **kwargs)
    File ".../osbs/osbs/api.py", line 74, in list_builds
        serialized_response = response.json()
    File ".../osbs/osbs/http.py", line 157, in json
        self._check_status_code()
    File ".../osbs/osbs/http.py", line 184, in _check_status_code
        raise HTTPError(url, self.status_code, message, None, None)
    HTTPError()