### PR TITLE
Better reporting for HTTP errors (#136)

### DIFF
--- a/osbs/exceptions.py
+++ b/osbs/exceptions.py
@@ -49,7 +49,9 @@ class OsbsResponseException(OsbsException):
 
 class OsbsNetworkException(OsbsException):
     def __init__(self, url, message, status_code, *args, **kwargs):
-        super(OsbsNetworkException, self).__init__(message, *args, **kwargs)
+        super(OsbsNetworkException, self).__init__("(%s) %s" % (status_code,
+                                                                message),
+                                                   *args, **kwargs)
         self.url = url
         self.status_code = status_code
 

--- a/osbs/http.py
+++ b/osbs/http.py
@@ -176,7 +176,7 @@ class Response(object):
             else:
                 url = None
             message = self._get_received_data()
-            raise HTTPError(url, self.status_code, message, None, None)
+            raise OsbsNetworkException(url, message, self.status_code)
 
     def _check_curl_errors(self):
         for f in self.curl_multi.info_read()[2]:


### PR DESCRIPTION
Fixes #136.

Now the output is:

```
Traceback (most recent call last):
  File "/usr/bin/osbs", line 9, in <module>
    load_entry_point('osbs==0.13.1', 'console_scripts', 'osbs')()
  File "build/bdist.linux-x86_64/egg/osbs/cli/main.py", line 319, in main
  File "build/bdist.linux-x86_64/egg/osbs/cli/main.py", line 130, in cmd_build
  File "build/bdist.linux-x86_64/egg/osbs/api.py", line 28, in catch_exceptions
  File "build/bdist.linux-x86_64/egg/osbs/api.py", line 232, in create_build
  File "build/bdist.linux-x86_64/egg/osbs/api.py", line 28, in catch_exceptions
  File "build/bdist.linux-x86_64/egg/osbs/api.py", line 168, in create_prod_with_secret_build
  File "build/bdist.linux-x86_64/egg/osbs/build/build_response.py", line 37, in json
  File "build/bdist.linux-x86_64/egg/osbs/http.py", line 156, in json
  File "build/bdist.linux-x86_64/egg/osbs/http.py", line 179, in _check_status_code
osbs.exceptions.OsbsNetworkException: (403) 
```
