### PR TITLE
Set resource limits for builds if specified (#85)

### DIFF
--- a/docs/resource.md
+++ b/docs/resource.md
@@ -1,0 +1,45 @@
+# Resource limiting
+
+To set resource quota, use `osc create -f quota.yaml` on a file like this:
+
+```yaml
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: myquota
+spec:
+  hard:
+    # Number of parallel builds
+    pods: 10
+    # Compute units (KCU) for all builds
+    cpu: "2"
+    # Memory for all builds
+    memory: 2Gi
+    # Storage for all builds
+    storage: 20Gi
+```
+
+Now `osc describe quota myquota` will show the used and total amount of each resource type.
+
+You can set default per-build limits either by setting them in the OSBS build configuration file (`cpu_limit`, `memory_limit`, `storage_limit`), or by setting defaults that OpenShift will apply to builds that do not specify their limits:
+
+```yaml
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limits
+spec:
+  limits:
+  - default:
+      # 100m == 0.1 KCU
+      cpu: 100m
+      memory: 512Mi
+      storage: 2Gi
+    type: Container
+```
+
+You can set per-build limits using the `--cpu-limit`, `--memory-limit`, and `--storage-limit` OSBS command line options.
+
+You can set quota for `pods`, `cpu`, `memory`, and `storage`, but you do not have to set quota for all of them. If you set quota for `cpu`, `memory`, or `storage`, you must also set limits for that resource: builds not specifying limits are unbounded and will not be admitted.
+
+You do not have to set limits for `pods`. Each build takes a fixed quantity (1 pod).

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -92,7 +92,20 @@ class OSBS(object):
         :return: instance of BuildRequest
         """
         build_type = build_type or self.build_conf.get_build_type()
-        return self.bm.get_build_request_by_type(build_type=build_type)
+        build_request = self.bm.get_build_request_by_type(build_type=build_type)
+
+        # Apply configured resource limits.
+        cpu_limit = self.build_conf.get_cpu_limit()
+        memory_limit = self.build_conf.get_memory_limit()
+        storage_limit = self.build_conf.get_storage_limit()
+        if (cpu_limit is not None or
+            memory_limit is not None or
+            storage_limit is not None):
+            build_request.set_resource_limits(cpu=cpu_limit,
+                                              memory=memory_limit,
+                                              storage=storage_limit)
+
+        return build_request
 
     @osbsapi
     def create_build_from_buildrequest(self, build_request, namespace=DEFAULT_NAMESPACE):

--- a/osbs/api.py
+++ b/osbs/api.py
@@ -99,8 +99,8 @@ class OSBS(object):
         memory_limit = self.build_conf.get_memory_limit()
         storage_limit = self.build_conf.get_storage_limit()
         if (cpu_limit is not None or
-            memory_limit is not None or
-            storage_limit is not None):
+                memory_limit is not None or
+                storage_limit is not None):
             build_request.set_resource_limits(cpu=cpu_limit,
                                               memory=memory_limit,
                                               storage=storage_limit)

--- a/osbs/cli/main.py
+++ b/osbs/cli/main.py
@@ -259,6 +259,12 @@ def cli():
                               dest="yum_repourls", help="URL of yum repo file")
     build_parser.add_argument("--source-secret", action='store', required=False,
                               help="resource name of source secret")
+    build_parser.add_argument("--cpu-limit", action='store', required=False,
+                              help="CPU limit (KCU)")
+    build_parser.add_argument("--memory-limit", action='store', required=False,
+                              help="memory limit")
+    build_parser.add_argument("--storage-limit", action='store', required=False,
+                              help="storage limit")
     build_parser.set_defaults(func=cmd_build)
 
     parser.add_argument("--openshift-uri", action='store', metavar="URL",

--- a/osbs/conf.py
+++ b/osbs/conf.py
@@ -222,3 +222,15 @@ class Configuration(object):
     def get_nfs_destination_dir(self):
         return self._get_value("nfs_dest_dir", self.conf_section,
                                "nfs_dest_dir", can_miss=True)
+
+    def get_cpu_limit(self):
+        return self._get_value("cpu_limit", self.conf_section,
+                               "cpu_limit", can_miss=True)
+
+    def get_memory_limit(self):
+        return self._get_value("memory_limit", self.conf_section,
+                               "memory_limit", can_miss=True)
+
+    def get_storage_limit(self):
+        return self._get_value("storage_limit", self.conf_section,
+                               "storage_limit", can_miss=True)


### PR DESCRIPTION
To set resource quota, use `osc create -f quota.yaml` on a file like this:

```yaml
apiVersion: v1
kind: ResourceQuota
metadata:
  name: quota
spec:
  hard:
    # Number of parallel builds
    pods: 10
    # Compute units (KCU) for all builds
    cpu: "2"
    # Memory for all builds
    memory: 2Gi
    # Storage for all builds
    storage: 20Gi
```

Now `osc describe quota myquota` will show the used and total amount of each resource type.

You can set default per-build limits either by setting them in the OSBS build configuration file (`cpu_limit`, `memory_limit`, `storage_limit`), or by setting defaults that OpenShift will apply to builds that do not specify their limits:

```yaml
apiVersion: v1
kind: LimitRange
metadata:
  name: limits
spec:
  limits:
  - default:
      # 100m == 0.1 KCU
      cpu: 100m
      memory: 512Mi
      storage: 2Gi
    type: Container
```

You can set per-build limits using the `--cpu-limit`, `--memory-limit`, and `--storage-limit` OSBS command line options.

You can set quota for `pods`, `cpu`, `memory`, and `storage`, but you do not have to set quota for all of them. If you set quota for `cpu`, `memory`, or `storage`, you must also set limits for that resource: builds not specifying limits are unbounded and will not be admitted.

You do not have to set limits for `pods`. Each build takes a fixed quantity (1 pod).

Fixes #85.